### PR TITLE
Review Data Api Heading Pages - Add Usage Examples  IJP-4081

### DIFF
--- a/wApi/java-api-setup.md
+++ b/wApi/java-api-setup.md
@@ -75,6 +75,45 @@ java -jar "./target/interject-webbapp-1.0.0-SNAPSHOT.jar"
 </blockquote>
 <br>
 
+### Making an API Call
+Once the API is running, you can test it with a simple health check request. Open a terminal and use curl:
+
+```bash
+curl http://127.0.0.1:8080/api/health
+```
+
+A successful response confirms the API is working:
+```json
+{
+  "status": "OK"
+}
+```
+<blockquote class="highlight_note">
+<details>
+<summary><strong>Alternative 1: Using PowerShell</strong></summary>
+<br>
+In PowerShell, <code>curl</code> is an alias for <code>Invoke-WebRequest</code> which returns a detailed object. For testing REST APIs, it's better to use the <code>Invoke-RestMethod</code> cmdlet, which automatically handles JSON.
+<br><br>
+<code class="language-powershell">
+Invoke-RestMethod http://127.0.0.1:8080/api/health
+</code>
+<br><br>
+This returns a PowerShell object. To use the literal curl application, you must specify <code>curl.exe</code>.
+</details>
+</blockquote>
+
+<blockquote class="highlight_note">
+<details>
+<summary><strong>Alternative 2: Using Postman</strong></summary>
+<br>
+1. Open a new request tab (click the <strong>+</strong> icon).<br>
+2. Ensure the HTTP method is set to <strong>GET</strong>.<br>
+3. In the URL bar, enter: <code>http://127.0.0.1:8080/api/health</code><br>
+4. Click the blue <strong>Send</strong> button.<br>
+5. In the response pane below, you will see a green <strong>Status: 200 OK</strong> and the JSON body.
+</details>
+</blockquote>
+
 ### Change Host and Port
 
 To change the host and port number, simply change the values in the `application.yaml` file:
@@ -84,6 +123,7 @@ server:
       port: 8080
       address: 127.0.0.1
 ```
+
 
 ### Development Docs
 

--- a/wApi/python-api-setup.md
+++ b/wApi/python-api-setup.md
@@ -135,6 +135,46 @@ Once settings have been configured, the server can be launched using the built-i
 ```
 python server.py
 ``` 
+### Making an API Call
+
+Once the API is running, you can test it to confirm it's working. 
+
+The simplest way is to use `curl` in your terminal to make a `GET` request to the health check endpoint.
+
+```bash
+curl http://127.0.0.1:8000/health
+```
+A successful request will return a `200 OK` status and the following JSON body:
+```json
+{
+  "status": "OK"
+}
+```
+<blockquote class="highlight_note">
+<details>
+<summary><strong>Alternative 1: Using PowerShell</strong></summary>
+<br>
+In PowerShell, <code>curl</code> is an alias for <code>Invoke-WebRequest</code> which returns a detailed object. For testing REST APIs, it's better to use the <code>Invoke-RestMethod</code> cmdlet, which automatically handles JSON.
+<br><br>
+<code class="language-powershell">
+Invoke-RestMethod http://127.0.0.1:8000/health
+</code>
+<br><br>
+This returns a PowerShell object. To use the literal curl application, you must specify <code>curl.exe</code>.
+</details>
+</blockquote>
+
+<blockquote class="highlight_note">
+<details>
+<summary><strong>Alternative 2: Using Postman</strong></summary>
+<br>
+1. Open a new request tab (click the <strong>+</strong> icon).<br>
+2. Ensure the HTTP method is set to <strong>GET</strong>.<br>
+3. In the URL bar, enter: <code>http://127.0.0.1:8000/health</code><br>
+4. Click the blue <strong>Send</strong> button.<br>
+5. In the response pane below, you will see a green <strong>Status: 200 OK</strong> and the JSON body.
+</details>
+</blockquote>
 
 ### More Information
 


### PR DESCRIPTION
This pull request improves the API setup documentation for both the Java and Python APIs by adding clear instructions on how to test that the API is running using different tools. The new sections guide users through making a health check call using curl, PowerShell, and Postman, making it easier for developers of all experience levels to verify their setup.

**API Usage Instructions:**

* Added a "Making an API Call" section to both `wApi/java-api-setup.md` and `wApi/python-api-setup.md`, demonstrating how to test the health check endpoint with curl and showing the expected JSON response. [[1]](diffhunk://#diff-8a3e15af8c86ee73c5391a6249d9517e1fe3735b22d281cfcdd5ec3482e007ebR78-R116) [[2]](diffhunk://#diff-9a7a3c26c7db7a92336e8d4e28438f51f4f2aa81bf36eda2154d31fdeb041b8fR138-R177)

* Provided alternative instructions for making the same API call using PowerShell (`Invoke-RestMethod`) and Postman, including step-by-step guidance for each tool. [[1]](diffhunk://#diff-8a3e15af8c86ee73c5391a6249d9517e1fe3735b22d281cfcdd5ec3482e007ebR78-R116) [[2]](diffhunk://#diff-9a7a3c26c7db7a92336e8d4e28438f51f4f2aa81bf36eda2154d31fdeb041b8fR138-R177)

**Documentation Organization:**

* Improved the flow of the setup guides by placing the API call instructions immediately after the section on starting the server, ensuring users can quickly verify their installation. [[1]](diffhunk://#diff-8a3e15af8c86ee73c5391a6249d9517e1fe3735b22d281cfcdd5ec3482e007ebR127) [[2]](diffhunk://#diff-9a7a3c26c7db7a92336e8d4e28438f51f4f2aa81bf36eda2154d31fdeb041b8fR138-R177)