### PR TITLE
Update Troubleshooting Page With Login Issue IJP-4126

### DIFF
--- a/wApi/java-api-setup.md
+++ b/wApi/java-api-setup.md
@@ -75,6 +75,45 @@ java -jar "./target/interject-webbapp-1.0.0-SNAPSHOT.jar"
 </blockquote>
 <br>
 
+### Making an API Call
+Once the API is running, you can test it with a simple health check request. Open a terminal and use curl:
+
+```bash
+curl http://127.0.0.1:8080/api/health
+```
+
+A successful response confirms the API is working:
+```json
+{
+  "status": "OK"
+}
+```
+<blockquote class="highlight_note">
+<details>
+<summary><strong>Alternative 1: Using PowerShell</strong></summary>
+<br>
+In PowerShell, <code>curl</code> is an alias for <code>Invoke-WebRequest</code> which returns a detailed object. For testing REST APIs, it's better to use the <code>Invoke-RestMethod</code> cmdlet, which automatically handles JSON.
+<br><br>
+<code class="language-powershell">
+Invoke-RestMethod http://127.0.0.1:8080/api/health
+</code>
+<br><br>
+This returns a PowerShell object. To use the literal curl application, you must specify <code>curl.exe</code>.
+</details>
+</blockquote>
+
+<blockquote class="highlight_note">
+<details>
+<summary><strong>Alternative 2: Using Postman</strong></summary>
+<br>
+1. Open a new request tab (click the <strong>+</strong> icon).<br>
+2. Ensure the HTTP method is set to <strong>GET</strong>.<br>
+3. In the URL bar, enter: <code>http://127.0.0.1:8080/api/health</code><br>
+4. Click the blue <strong>Send</strong> button.<br>
+5. In the response pane below, you will see a green <strong>Status: 200 OK</strong> and the JSON body.
+</details>
+</blockquote>
+
 ### Change Host and Port
 
 To change the host and port number, simply change the values in the `application.yaml` file:
@@ -84,6 +123,7 @@ server:
       port: 8080
       address: 127.0.0.1
 ```
+
 
 ### Development Docs
 

--- a/wApi/python-api-setup.md
+++ b/wApi/python-api-setup.md
@@ -135,6 +135,46 @@ Once settings have been configured, the server can be launched using the built-i
 ```
 python server.py
 ``` 
+### Making an API Call
+
+Once the API is running, you can test it to confirm it's working. 
+
+The simplest way is to use `curl` in your terminal to make a `GET` request to the health check endpoint.
+
+```bash
+curl http://127.0.0.1:8000/health
+```
+A successful request will return a `200 OK` status and the following JSON body:
+```json
+{
+  "status": "OK"
+}
+```
+<blockquote class="highlight_note">
+<details>
+<summary><strong>Alternative 1: Using PowerShell</strong></summary>
+<br>
+In PowerShell, <code>curl</code> is an alias for <code>Invoke-WebRequest</code> which returns a detailed object. For testing REST APIs, it's better to use the <code>Invoke-RestMethod</code> cmdlet, which automatically handles JSON.
+<br><br>
+<code class="language-powershell">
+Invoke-RestMethod http://127.0.0.1:8000/health
+</code>
+<br><br>
+This returns a PowerShell object. To use the literal curl application, you must specify <code>curl.exe</code>.
+</details>
+</blockquote>
+
+<blockquote class="highlight_note">
+<details>
+<summary><strong>Alternative 2: Using Postman</strong></summary>
+<br>
+1. Open a new request tab (click the <strong>+</strong> icon).<br>
+2. Ensure the HTTP method is set to <strong>GET</strong>.<br>
+3. In the URL bar, enter: <code>http://127.0.0.1:8000/health</code><br>
+4. Click the blue <strong>Send</strong> button.<br>
+5. In the response pane below, you will see a green <strong>Status: 200 OK</strong> and the JSON body.
+</details>
+</blockquote>
 
 ### More Information
 

--- a/wTroubleshoot/TroubleshootingGuide.md
+++ b/wTroubleshoot/TroubleshootingGuide.md
@@ -3,7 +3,7 @@ title: Troubleshooting Guide
 filename: "TroubleshootingGuide.md"
 layout: custom
 keywords: [errors, solutions, fix]
-headings: ["Overview", "Error: Add-in Not Completely Loaded", "Error: Incompatible FIPS", "Error: Interject Web API Offline", "Error: Can't Install or Uninstall Interject", "Error: Interject Add-in Ribbon is Gone", "Error: Cannot Connect or Communicate With Interject Platform", "Error: Login Page Not Showing (ver 2.5+)", "Error: File Not Uploading Correctly to Report Library", "Error: Report Showing Incorrect Data or Data Missing"]
+headings: ["Overview", "Error: Add-in Not Completely Loaded", "Error: Incompatible FIPS", "Error: Interject Web API Offline", "Error: Can't Install or Uninstall Interject", "Error: Interject Add-in Ribbon is Gone", "Error: Cannot Connect or Communicate With Interject Platform", "Error: Login Button Does Nothing", "Error: Login Page Not Showing (ver 2.5+)", "Error: File Not Uploading Correctly to Report Library", "Error: Report Showing Incorrect Data or Data Missing"]
 links: ["https://portal.gointerject.com/download-interject.html", "/wDeveloper/TLS.html", "/wDeveloper/Enterprise-Login-Setup.html#ip-whitelisting", "https://support.microsoft.com/en-us/topic/fix-problems-that-block-programs-from-being-installed-or-removed-cca7d1b6-65a9-3d98-426b-e9f927e1eb4d", "/wTroubleshoot/CorruptedInstallation.html", "/wTroubleshoot/Addin-Missing.html", "/wDeveloper/Enterprise-Login-Setup.html#ip-whitelisting", "/wTroubleshoot/WebView2.html", "/wIndex/Diagnostics-SpecialFeatures.html#webview2browser-login", "/wDeveloper/Enterprise-Login-Setup.html#ip-whitelisting", "https://live-interject-authapi.azurewebsites.net/", "https://live-interject-authapi.azurewebsites.net/.well-known/openid-configuration", "https://live-interject-authapi.azurewebsites.net/", "/wTroubleshoot/Cloud-File.html#solution-saving-to-local-drive", "/wTroubleshoot/Cloud-File.html#solution-uploading-as-a-website-link", "/wFunctions/Excel-Function-Index.html", "https://portal.gointerject.com/download-interject.html#additionalInstallers"]
 image_dir: ""
 images: []
@@ -68,6 +68,19 @@ _"One or more of the Interject web apis are offline or could not be reached. The
 - <span style="color: red;">ISSUE:</span> Proxy network is blocking outgoing traffic
 
     <span style="color: green;">SOLUTION:</span> [Whitelist](/wDeveloper/Enterprise-Login-Setup.html#ip-whitelisting) our auth API URL
+
+### Error: Login Button Does Nothing
+
+When clicking the login button, nothing happens and the login page does not load.
+
+- <span style="color: red;">ISSUE:</span> This occurs when the Interject Add-in is unable to use the WebView2 browser engine to render the login page.
+
+- <span style="color: green;">SOLUTION (Step 1):</span> Switch the login page rendering to the default browser (set `WebView2 = false`) using the Interject Diagnostics menu. [Browser Login Settings](https://docs.gointerject.com/wIndex/Diagnostics-SpecialFeatures.html#webview2browser-login).
+
+- <span style="color: red;">ISSUE:</span> After switching to the default browser, you may see this additional error:
+"An error occurred while loading the system settings. An unexpected XML format was used. See logs."
+
+- <span style="color: green;">SOLUTION (Step 2):</span> Delete the contents of the `%appdata%\Interject\Settings` folder (or `C:\Users\<username>\AppData\Roaming\Interject\Settings`). These files will be automatically regenerated when you log in again.
 
 ### Error: Login Page Not Showing (ver 2.5+)
 


### PR DESCRIPTION
This PR updates the Troubleshooting Guide with a new section covering cases where clicking the login button does nothing.

### Added new section: “Error: Login Button Does Nothing”

- Documents the root cause of the issue (failure to render login page with WebView2).

- Provides Step 1 solution to switch to the default browser (WebView2 = false).

### Includes Step 2 solution for the follow-up error:
"An error occurred while loading the system settings. An unexpected XML format was used. See logs."

- Resolved by deleting the contents of the %appdata%\Interject\Settings folder (automatically regenerated on next login).

- Inserted the new section above the existing “Error: Login Page Not Showing (ver 2.5+)” section to preserve logical flow of login-related issues.

### Updated front-matter headings to include the new error section.

- This ensures both the root login issue and the secondary XML error are covered in the troubleshooting documentation.